### PR TITLE
add a property to tell rest api to only return published sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ All the properties are optional. If they are not included the default values are
     ## Domain configuration
     # the iclicker domain URL, DEFAULT: the Sakai server URL (e.g. http://your.server.edu)
     #iclicker.domainurl={server url}
+    #iclicker REST service /courses to return only published sites, DEFAULT: false
+    #iclicker.get.published.courses.only=false
 
 NOTE on Single Sign-On::
 

--- a/src/main/java/org/sakaiproject/iclicker/logic/AbstractExternalLogic.java
+++ b/src/main/java/org/sakaiproject/iclicker/logic/AbstractExternalLogic.java
@@ -104,6 +104,7 @@ public abstract class AbstractExternalLogic {
     public static final String GENERAL_ERRORS = "GeneralErrors";
 
     public String serverId = "UNKNOWN_SERVER_ID";
+    public Boolean publishedSitesOnly = false;
 
     public static final String NO_LOCATION = "noLocationAvailable";
 
@@ -121,6 +122,7 @@ public abstract class AbstractExternalLogic {
 
     public void init() {
         serverId = getConfigurationSetting(AbstractExternalLogic.SETTING_SERVER_ID, serverId);
+        publishedSitesOnly = getConfigurationSetting("iclicker.get.published.courses.only", publishedSitesOnly);
     }
 
     /**
@@ -506,6 +508,11 @@ public abstract class AbstractExternalLogic {
             }
 
             instSites.add(site);
+        }
+
+        // filter out unpublished sites
+        if (publishedSitesOnly && !site.isPublished()) {
+            continue;
         }
 
         return instSites;


### PR DESCRIPTION
We had several instructors who had a lot of courses, so in the "instructor report" tab, it was difficult to see which sites were active or published vs. unpublished.  Plus, the iclicker desktop app only displays published sites, so it wouldn't be that far of a stretch for the tool to only show published sites as well.  And this feature will be configurable by adding a property to sakai.properties